### PR TITLE
Switched source path to fix Intellij import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "sbt-groovy"
 
 organization := "org.softnetwork.sbt.plugins"
 
-version := "0.1"
+version := "0.1.1"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.4"
 
 publishMavenStyle := true
 

--- a/src/main/scala/GroovyPlugin.scala
+++ b/src/main/scala/GroovyPlugin.scala
@@ -22,7 +22,7 @@ object GroovyPlugin extends Plugin {
   object groovy extends Keys {
     val settings = Seq(ivyConfigurations += Config) ++ GroovyDefaults.settings ++ Seq(
       groovySource in Compile := (sourceDirectory in Compile).value / "groovy",
-      unmanagedResourceDirectories in Compile += {(groovySource in Compile).value},
+      unmanagedSourceDirectories in Compile += {(groovySource in Compile).value},
       generateStubs in Compile := {
         val sourceDirectory : File = (groovySource in Compile).value
         val nb = (sourceDirectory ** "*.groovy").get.size
@@ -71,7 +71,7 @@ object GroovyPlugin extends Plugin {
       fullClasspath <<= fullClasspath in Test,
 
       groovySource in Test := (sourceDirectory in Test).value / "groovy",
-      unmanagedResourceDirectories in Test += {(groovySource in Test).value},
+      unmanagedSourceDirectories in Test += {(groovySource in Test).value},
       generateStubs in Test := {
         val sourceDirectory : File = (groovySource in Test).value
         val nb = (sourceDirectory ** "*.groovy").get.size


### PR DESCRIPTION
Using unmanagedResourceDirectories causes Intellij to treat the groovy folder as a resources folder instead of a source directory.  Switching this to unmanagedSourceDirectories fixes the problem with Intellij and still maintains the existing functionality.
